### PR TITLE
Update csvplugin.py

### DIFF
--- a/csvplugin.py
+++ b/csvplugin.py
@@ -65,7 +65,7 @@ class CSVMatrix:
         self.valid = False
 
         self.delimiter = self.settings.get('delimiter')
-        if not isinstance(self.delimiter, str) or len(self.delimiter) != 1:
+        if not isinstance(self.delimiter, unicode) or len(self.delimiter) != 1:
             print("'{0}' is not a valid delimiter, reverting to ','.".format(self.delimiter))
             self.delimiter = ','
 


### PR DESCRIPTION
Hi guys,

in the line i changed the following code 
```python
 sublime.settings.get('delimiter')
```

 delivers a `unicode`, not a `str`. The check with `instanceof` fails therefor.

You can see a message like 

    ',' is not a valid delimiter, reverting to ','."

in commandline.

Please check if i'm right. Maybe it is caused somewhere else. In my Installation i tried it and it worked. 
I initialy found it while changing the delimiter from comma to a semicolon.