### PR TITLE
Added CSV:Format function

### DIFF
--- a/Context.sublime-menu
+++ b/Context.sublime-menu
@@ -48,6 +48,10 @@
             {
                 "command": "csv_evaluate",
                 "caption": "Evaluate cells"
+            },
+            {
+                "command": "csv_format",
+                "caption": "Format by template"
             }
         ]
     }

--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -6,5 +6,6 @@
     {"keys": ["ctrl+,","s"], "command": "csv_select_col"},
     {"keys": ["ctrl+,"," "], "command": "csv_format_expand"},
     {"keys": ["ctrl+,",","], "command": "csv_format_compact"},
-    {"keys": ["ctrl+,","="], "command": "csv_evaluate"}
+    {"keys": ["ctrl+,","="], "command": "csv_evaluate"},
+    {"keys": ["ctrl+,","f"], "command": "csv_format"}
 ]

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -6,5 +6,6 @@
     {"keys": ["ctrl+,","s"], "command": "csv_select_col"},
     {"keys": ["ctrl+,"," "], "command": "csv_format_expand"},
     {"keys": ["ctrl+,",","], "command": "csv_format_compact"},
-    {"keys": ["ctrl+,","="], "command": "csv_evaluate"}
+    {"keys": ["ctrl+,","="], "command": "csv_evaluate"},
+    {"keys": ["ctrl+,","f"], "command": "csv_format"}
 ]

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -6,5 +6,6 @@
     {"keys": ["ctrl+,","s"], "command": "csv_select_col"},
     {"keys": ["ctrl+,"," "], "command": "csv_format_expand"},
     {"keys": ["ctrl+,",","], "command": "csv_format_compact"},
-    {"keys": ["ctrl+,","="], "command": "csv_evaluate"}
+    {"keys": ["ctrl+,","="], "command": "csv_evaluate"},
+    {"keys": ["ctrl+,","f"], "command": "csv_format"}
 ]

--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -34,5 +34,9 @@
     {
         "command": "csv_evaluate",
         "caption": "CSV: Evaluate cells"
+    },
+    {
+        "command": "csv_format",
+        "caption": "CSV: Format"
     }
 ]

--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -55,7 +55,12 @@
                     {
                         "command": "csv_evaluate",
                         "caption": "Evaluate cells"
+                    },
+                    {
+                        "command": "csv_format",
+                        "caption": "Format by template"
                     }
+
                 ]
             }
         ]

--- a/csvplugin.py
+++ b/csvplugin.py
@@ -674,9 +674,7 @@ class CsvFormatCommand(sublime_plugin.WindowCommand):
         self.window.show_input_panel('Format (Values as 0 based column between {})', "",
             self.on_done, self.on_change, self.on_cancel)
 
-    def on_done(self, input):
-        use_header = GetFileSetting(self.window.active_view(), 'use_header')
-        
+    def on_done(self, input):             
         output = ''
         numrows = len(self.matrix.rows)
         for rowindex, row in enumerate(self.matrix.rows):
@@ -698,43 +696,3 @@ class CsvFormatCommand(sublime_plugin.WindowCommand):
 
     def on_cancel(self):
         pass
-
-def SetFileSetting(view, key, value):
-    filename = view.file_name()
-    settings = sublime.load_settings(__name__ + '.sublime-settings')
-
-    filesettings = settings.get('csv_per_file_setting', [])
-
-    foundsetting = False
-
-    for filesetting in filesettings:
-        if filesetting['file'] == filename:
-            foundsetting = True
-            filesetting[key] = value
-            break
-
-    if not foundsetting:
-        filesetting = {}
-        filesetting['file'] = filename
-        filesetting[key] = value
-        filesettings.append(filesetting)
-
-    settings.set('csv_per_file_setting', filesettings)
-    sublime.save_settings(__name__ + '.sublime-settings')
-
-def GetFileSetting(view, key):
-    filename = view.file_name()
-    settings = sublime.load_settings(__name__ + '.sublime-settings')
-
-    filesettings = settings.get('csv_per_file_setting', [])
-
-    foundsetting = False
-
-    for filesetting in filesettings:
-        if filesetting['file'] == filename:
-            return filesetting[key]
-
-    if not foundsetting:
-        return False
-
-


### PR DESCRIPTION
from https://github.com/ericmartel/Sublime-Text-2-CSV-Plugin

with small changes to make it work in this project

This function let you format CSV text to plain text with template.
Very useful if you want to make .PO files or .XML files from CSV files

Usage: in Sublime press Ctrl + Shift + P
write CSV:Format
In the opened line add your template. Use {0} , {1} , {....} for columns of your CSV file
For example if your CSV file have fields:

Field_A ,   Field_B

11111   ,   22222

and you will use format {0} ***** {1}

You recive file with data:

11111 ***** 22222