### PR TITLE
Sublime Text doesn't like the comma here

### DIFF
--- a/AdvancedCSV.sublime-settings
+++ b/AdvancedCSV.sublime-settings
@@ -2,7 +2,7 @@
   "delimiter_mapping": {
   	"*.csv": ",",
   	"*.psv": "|",
-  	"*.tsv": "\t",
+  	"*.tsv": "\t"
   },
   "delimiter": ",",
   "auto_quote": true


### PR DESCRIPTION
Sublime Text 2 will pop up an error on installing with Package Control, because the comma is followed by a closing bracket. Removing it should fix it!