### PR TITLE
Auto activate package for TSV files

### DIFF
--- a/AdvancedCSV.YAML-tmLanguage
+++ b/AdvancedCSV.YAML-tmLanguage
@@ -1,7 +1,7 @@
 # [PackageDev] target_format: plist, ext: tmLanguage
 ---
 name: Advanced CSV
-fileTypes: [csv]
+fileTypes: [csv, tsv]
 scopeName: text.advanced_csv
 uuid: 7ce133ea-e34b-47d9-a03c-341293337c88
 

--- a/AdvancedCSV.tmLanguage
+++ b/AdvancedCSV.tmLanguage
@@ -5,6 +5,7 @@
 	<key>fileTypes</key>
 	<array>
 		<string>csv</string>
+		<string>tsv</string>
 	</array>
 	<key>name</key>
 	<string>Advanced CSV</string>


### PR DESCRIPTION
I use this Sublime Text package pretty much every day. But one of the things that annoys me the most is that it doesn't automatically activate when opening a TSV file. I think this change should fix this.